### PR TITLE
`project.godot` changes

### DIFF
--- a/demo/project.godot
+++ b/demo/project.godot
@@ -10,6 +10,10 @@ config_version=5
 
 [application]
 
-config/name="Demo"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/name="UtilityAI Demo"
+config/features=PackedStringArray("4.1", "GL Compatibility")
 config/icon="res://icon.svg"
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Changed title to "UtilityAI Demo" to better understand what project it is from Project Manager. Switched rendering method to `gl_compatibility` so that demo project could be opened by people which device doesn't support Vulkan. Switched version to 4.1 as this is the minimal-supported one.