### PR TITLE
Switch from using NodePaths to using Nodes

### DIFF
--- a/src/BehaviourTree/UtilityAIBTNodeReference.h
+++ b/src/BehaviourTree/UtilityAIBTNodeReference.h
@@ -14,12 +14,9 @@ class UtilityAIBTNodeReference : public UtilityAIBTTaskNodes {
 private:
     
     //int _tick_result;
-    ObjectID    _cache;
-    NodePath    _node_reference_nodepath;
+    UtilityAIBehaviourTreeNodes* _node_reference;
 protected:
     static void _bind_methods();
-
-    void _update_cache();
 public:
     UtilityAIBTNodeReference();
     ~UtilityAIBTNodeReference();
@@ -27,17 +24,14 @@ public:
     
     // Getters and setters for attributes.
     
-    void set_node_reference_nodepath(const NodePath &node_reference_nodepath);
-	NodePath get_node_reference_nodepath() const;
+    void set_node_reference(UtilityAIBehaviourTreeNodes* node_reference);
+	UtilityAIBehaviourTreeNodes* get_node_reference() const;
     //void set_tick_result( int tick_result );
     //int  get_tick_result() const;
 
     // Handling functions.
     virtual void reset() override;
     virtual int tick(Variant user_data, double delta) override;
-
-    // Godot virtuals.
-    void _enter_tree();
 };
 
 }

--- a/src/BehaviourTree/UtilityAIBTRunNQSQuery.h
+++ b/src/BehaviourTree/UtilityAIBTRunNQSQuery.h
@@ -16,8 +16,7 @@ class UtilityAIBTRunNQSQuery : public UtilityAIBTTaskNodes {
     GDCLASS(UtilityAIBTRunNQSQuery, UtilityAIBTTaskNodes)
 
 private:
-    NodePath _nqs_search_space_node_path;
-    UtilityAINQSSearchSpaces* _nqs_search_space_node;
+    UtilityAINQSSearchSpaces* _nqs_search_space;
     UtilityAINodeQuerySystem* _nqs;
 
     int  _time_budget_usec;
@@ -35,8 +34,8 @@ public:
     
     // Getters and setters for attributes.
         
-    void set_nqs_search_space_node_path( NodePath nqs_search_space_node_path );
-    NodePath get_nqs_search_space_node_path() const;
+    void set_nqs_search_space( UtilityAINQSSearchSpaces* nqs_search_space );
+    UtilityAINQSSearchSpaces* get_nqs_search_space() const;
 
     void set_time_budget_usec( int time_budget_usec );
     int  get_time_budget_usec() const;

--- a/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode2DSearchCriterion.cpp
+++ b/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode2DSearchCriterion.cpp
@@ -11,20 +11,20 @@ UtilityAIDistanceToNode2DSearchCriterion::UtilityAIDistanceToNode2DSearchCriteri
     _max_distance_squared = _max_distance * _max_distance;
     _span_length = _max_distance_squared - _min_distance_squared;
     _one_over_span_length = 1.0 / _span_length;
-    _distance_to_node = nullptr;
+    _distance_to = nullptr;
 }
 
 
 UtilityAIDistanceToNode2DSearchCriterion::~UtilityAIDistanceToNode2DSearchCriterion() {
-    _distance_to_node = nullptr;
+    _distance_to = nullptr;
 }
 
 
 void UtilityAIDistanceToNode2DSearchCriterion::_bind_methods() {
     
-    ClassDB::bind_method(D_METHOD("set_distance_to_nodepath", "distance_to_nodepath"), &UtilityAIDistanceToNode2DSearchCriterion::set_distance_to_nodepath);
-    ClassDB::bind_method(D_METHOD("get_distance_to_nodepath"), &UtilityAIDistanceToNode2DSearchCriterion::get_distance_to_nodepath);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "distance_to_nodepath", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node2D"), "set_distance_to_nodepath","get_distance_to_nodepath");
+    ClassDB::bind_method(D_METHOD("set_distance_to", "distance_to"), &UtilityAIDistanceToNode2DSearchCriterion::set_distance_to);
+    ClassDB::bind_method(D_METHOD("get_distance_to"), &UtilityAIDistanceToNode2DSearchCriterion::get_distance_to);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "distance_to", PROPERTY_HINT_NODE_TYPE, "Node2D"), "set_distance_to", "get_distance_to");
     
     ClassDB::bind_method(D_METHOD("set_min_distance", "min_distance"), &UtilityAIDistanceToNode2DSearchCriterion::set_min_distance);
     ClassDB::bind_method(D_METHOD("get_min_distance"), &UtilityAIDistanceToNode2DSearchCriterion::get_min_distance);
@@ -39,21 +39,18 @@ void UtilityAIDistanceToNode2DSearchCriterion::_bind_methods() {
 
 
 void UtilityAIDistanceToNode2DSearchCriterion::_initialize_criterion() {
-    Node* node = get_node_or_null(_distance_to_nodepath);
-    if( node == nullptr ) return;
-    _distance_to_node = godot::Object::cast_to<Node2D>(node);
 }
 
 
 // Getters and setters.
 
-void UtilityAIDistanceToNode2DSearchCriterion::set_distance_to_nodepath( NodePath distance_to_nodepath ) {
-    _distance_to_nodepath = distance_to_nodepath;
+void UtilityAIDistanceToNode2DSearchCriterion::set_distance_to( Node2D* distance_to ) {
+    _distance_to = distance_to;
 }
 
 
-NodePath UtilityAIDistanceToNode2DSearchCriterion::get_distance_to_nodepath() const {
-    return _distance_to_nodepath;
+Node2D* UtilityAIDistanceToNode2DSearchCriterion::get_distance_to() const {
+    return _distance_to;
 }
 
 
@@ -92,14 +89,14 @@ double UtilityAIDistanceToNode2DSearchCriterion::get_max_distance() const {
 // Handing methods.
 
 void UtilityAIDistanceToNode2DSearchCriterion::apply_criterion( Node* node, bool& filter_out, double& score ) {
-    if( _distance_to_node == nullptr ) return;
+    if( _distance_to == nullptr ) return;
     Node2D* node2d = godot::Object::cast_to<Node2D>(node);
     if( node2d == nullptr ) return;
     
     _is_filtered = false;
     _score = 0.0;
 
-    Vector2 from_to = node2d->get_global_position() - _distance_to_node->get_global_position();
+    Vector2 from_to = node2d->get_global_position() - _distance_to->get_global_position();
     double distance_squared = from_to.length_squared();
     
     if( get_use_for_filtering() ) {

--- a/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode2DSearchCriterion.h
+++ b/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode2DSearchCriterion.h
@@ -20,8 +20,7 @@ private:
     double _span_length;
     double _one_over_span_length;
 
-    NodePath _distance_to_nodepath;
-    Node2D*  _distance_to_node;
+    Node2D*  _distance_to;
 
 protected:
     static void _bind_methods();
@@ -33,8 +32,8 @@ public:
     
     // Getters and setters for attributes.
 
-    void set_distance_to_nodepath( NodePath distance_to_nodepath );
-    NodePath get_distance_to_nodepath() const;
+    void set_distance_to( Node2D* distance_to );
+    Node2D* get_distance_to() const;
 
 
     void set_min_distance( double min_distance );

--- a/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode3DSearchCriterion.cpp
+++ b/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode3DSearchCriterion.cpp
@@ -11,20 +11,20 @@ UtilityAIDistanceToNode3DSearchCriterion::UtilityAIDistanceToNode3DSearchCriteri
     _max_distance_squared = _max_distance * _max_distance;
     _span_length = _max_distance_squared - _min_distance_squared;
     _one_over_span_length = 1.0 / _span_length;
-    _distance_to_node = nullptr;
+    _distance_to = nullptr;
 }
 
 
 UtilityAIDistanceToNode3DSearchCriterion::~UtilityAIDistanceToNode3DSearchCriterion() {
-    _distance_to_node = nullptr;
+    _distance_to = nullptr;
 }
 
 
 void UtilityAIDistanceToNode3DSearchCriterion::_bind_methods() {
     
-    ClassDB::bind_method(D_METHOD("set_distance_to_nodepath", "distance_to_nodepath"), &UtilityAIDistanceToNode3DSearchCriterion::set_distance_to_nodepath);
-    ClassDB::bind_method(D_METHOD("get_distance_to_nodepath"), &UtilityAIDistanceToNode3DSearchCriterion::get_distance_to_nodepath);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "distance_to_nodepath", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node3D"), "set_distance_to_nodepath","get_distance_to_nodepath");
+    ClassDB::bind_method(D_METHOD("set_distance_to", "distance_to"), &UtilityAIDistanceToNode3DSearchCriterion::set_distance_to);
+    ClassDB::bind_method(D_METHOD("get_distance_to"), &UtilityAIDistanceToNode3DSearchCriterion::get_distance_to);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "distance_to", PROPERTY_HINT_NODE_TYPE, "Node3D"), "set_distance_to", "get_distance_to");
     
     ClassDB::bind_method(D_METHOD("set_min_distance", "min_distance"), &UtilityAIDistanceToNode3DSearchCriterion::set_min_distance);
     ClassDB::bind_method(D_METHOD("get_min_distance"), &UtilityAIDistanceToNode3DSearchCriterion::get_min_distance);
@@ -39,21 +39,18 @@ void UtilityAIDistanceToNode3DSearchCriterion::_bind_methods() {
 
 
 void UtilityAIDistanceToNode3DSearchCriterion::_initialize_criterion() {
-    Node* node = get_node_or_null(_distance_to_nodepath);
-    if( node == nullptr ) return;
-    _distance_to_node = godot::Object::cast_to<Node3D>(node);
 }
 
 
 // Getters and setters.
 
-void UtilityAIDistanceToNode3DSearchCriterion::set_distance_to_nodepath( NodePath distance_to_nodepath ) {
-    _distance_to_nodepath = distance_to_nodepath;
+void UtilityAIDistanceToNode3DSearchCriterion::set_distance_to( Node3D* distance_to ) {
+    _distance_to = distance_to;
 }
 
 
-NodePath UtilityAIDistanceToNode3DSearchCriterion::get_distance_to_nodepath() const {
-    return _distance_to_nodepath;
+Node3D* UtilityAIDistanceToNode3DSearchCriterion::get_distance_to() const {
+    return _distance_to;
 }
 
 
@@ -92,14 +89,14 @@ double UtilityAIDistanceToNode3DSearchCriterion::get_max_distance() const {
 // Handing methods.
 
 void UtilityAIDistanceToNode3DSearchCriterion::apply_criterion( Node* node, bool& filter_out, double& score ) {
-    if( _distance_to_node == nullptr ) return;
+    if( _distance_to == nullptr ) return;
     Node3D* node3d = godot::Object::cast_to<Node3D>(node);
     if( node3d == nullptr ) return;
     
     _is_filtered = false;
     _score = 0.0;
 
-    Vector3 from_to = node3d->get_global_position() - _distance_to_node->get_global_position();
+    Vector3 from_to = node3d->get_global_position() - _distance_to->get_global_position();
     double distance_squared = from_to.length_squared();
     
     if( get_use_for_filtering() ) {

--- a/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode3DSearchCriterion.h
+++ b/src/NodeQuerySystem/SearchCriteria/UtilityAIDistanceToNode3DSearchCriterion.h
@@ -20,8 +20,7 @@ private:
     double _span_length;
     double _one_over_span_length;
 
-    NodePath _distance_to_nodepath;
-    Node3D*  _distance_to_node;
+    Node3D*  _distance_to;
 
 protected:
     static void _bind_methods();
@@ -33,8 +32,8 @@ public:
     
     // Getters and setters for attributes.
 
-    void set_distance_to_nodepath( NodePath distance_to_nodepath );
-    NodePath get_distance_to_nodepath() const;
+    void set_distance_to( Node3D* distance_to );
+    Node3D* get_distance_to() const;
 
 
     void set_min_distance( double min_distance );

--- a/src/NodeQuerySystem/SearchSpaces/UtilityAIArea2DSearchSpace.cpp
+++ b/src/NodeQuerySystem/SearchSpaces/UtilityAIArea2DSearchSpace.cpp
@@ -4,7 +4,7 @@ using namespace godot;
 
 
 UtilityAIArea2DSearchSpace::UtilityAIArea2DSearchSpace() {
-    _area2d_node = nullptr;
+    _area2d = nullptr;
 }
 
 
@@ -16,9 +16,9 @@ void UtilityAIArea2DSearchSpace::_bind_methods() {
 
     ADD_SUBGROUP("Configuration","");
 
-    ClassDB::bind_method(D_METHOD("set_area2d_nodepath", "area2D_nodepath"), &UtilityAIArea2DSearchSpace::set_area2d_nodepath);
-    ClassDB::bind_method(D_METHOD("get_area2d_nodepath"), &UtilityAIArea2DSearchSpace::get_area2d_nodepath);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "area2d_nodepath", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Area2D"), "set_area2d_nodepath","get_area2d_nodepath");
+    ClassDB::bind_method(D_METHOD("set_area2d", "area2D"), &UtilityAIArea2DSearchSpace::set_area2d);
+    ClassDB::bind_method(D_METHOD("get_area2d"), &UtilityAIArea2DSearchSpace::get_area2d);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "area2d", PROPERTY_HINT_NODE_TYPE, "Area2D"), "set_area2d", "get_area2d");
 
     ClassDB::bind_method(D_METHOD("on_area_entered", "area"), &UtilityAIArea2DSearchSpace::on_area_entered);
     ClassDB::bind_method(D_METHOD("on_area_exited", "area"), &UtilityAIArea2DSearchSpace::on_area_exited);
@@ -58,13 +58,13 @@ void UtilityAIArea2DSearchSpace::on_area_exited(Area2D* area ) {
     
 // Getters and setters for attributes.
 
-void UtilityAIArea2DSearchSpace::set_area2d_nodepath( NodePath area2d_nodepath ) {
-    _area2d_nodepath = area2d_nodepath;
+void UtilityAIArea2DSearchSpace::set_area2d( Area2D* area2d ) {
+    _area2d = area2d;
 }
 
 
-NodePath UtilityAIArea2DSearchSpace::get_area2d_nodepath() const {
-    return _area2d_nodepath;
+Area2D* UtilityAIArea2DSearchSpace::get_area2d() const {
+    return _area2d;
 }
 
 
@@ -86,24 +86,21 @@ TypedArray<Node> UtilityAIArea2DSearchSpace::get_searchspace_nodes() const {
 
 
 void UtilityAIArea2DSearchSpace::_initialize_search_space() {
-    Node* node = get_node_or_null(_area2d_nodepath);
-    ERR_FAIL_COND_MSG( node == nullptr, "UtilityAIArea2DSearchSpace::_initialize_search_space() - Error, the nodepath for the Area2D has not been set.");
-    _area2d_node = godot::Object::cast_to<Area2D>(node);
-    ERR_FAIL_COND_MSG( _area2d_node == nullptr, "UtilityAIArea2DSearchSpace::_initialize_sensor() - Error, the node set as the Area2D is not of type Area2D.");
+    ERR_FAIL_COND_MSG( _area2d == nullptr, "UtilityAIArea2DSearchSpace::_initialize_search_space() - Error, the node for the Area2D has not been set.");
     
     // Connect to the area entered and exited signals.
-    Error error_visibility_volume_on_entered = _area2d_node->connect("area_entered", Callable(this, "on_area_entered"));
-    Error error_visibility_volume_on_exited  = _area2d_node->connect("area_exited", Callable(this, "on_area_exited"));
+    Error error_visibility_volume_on_entered = _area2d->connect("area_entered", Callable(this, "on_area_entered"));
+    Error error_visibility_volume_on_exited  = _area2d->connect("area_exited", Callable(this, "on_area_exited"));
 
 }
 
 
 
 void UtilityAIArea2DSearchSpace::_uninitialize_search_space() {
-    if( _area2d_node != nullptr ) {
-        _area2d_node->disconnect("area_entered", Callable(this, "on_area_entered"));
-        _area2d_node->disconnect("area_exited", Callable(this, "on_area_exited"));
+    if( _area2d != nullptr ) {
+        _area2d->disconnect("area_entered", Callable(this, "on_area_entered"));
+        _area2d->disconnect("area_exited", Callable(this, "on_area_exited"));
     }
-    _area2d_node = nullptr;
+    _area2d = nullptr;
 }
 

--- a/src/NodeQuerySystem/SearchSpaces/UtilityAIArea2DSearchSpace.h
+++ b/src/NodeQuerySystem/SearchSpaces/UtilityAIArea2DSearchSpace.h
@@ -10,8 +10,7 @@ class UtilityAIArea2DSearchSpace : public UtilityAINQSSearchSpaces {
     GDCLASS(UtilityAIArea2DSearchSpace, UtilityAINQSSearchSpaces)
 
 private:
-    NodePath _area2d_nodepath;
-    Area2D* _area2d_node;
+    Area2D* _area2d;
 
     TypedArray<Area2D> _intersecting_areas;
 protected:
@@ -28,8 +27,8 @@ public:
     
     // Getters and setters for attributes.
 
-    void set_area2d_nodepath( NodePath area2d_nodepath );
-    NodePath get_area2d_nodepath() const;
+    void set_area2d( Area2D* area2d );
+    Area2D* get_area2d() const;
 
     void set_intersecting_areas( TypedArray<Area2D> intersecting_areas );
     TypedArray<Area2D> get_intersecting_areas() const;

--- a/src/NodeQuerySystem/SearchSpaces/UtilityAIArea3DSearchSpace.cpp
+++ b/src/NodeQuerySystem/SearchSpaces/UtilityAIArea3DSearchSpace.cpp
@@ -4,7 +4,7 @@ using namespace godot;
 
 
 UtilityAIArea3DSearchSpace::UtilityAIArea3DSearchSpace() {
-    _area3d_node = nullptr;
+    _area3d = nullptr;
 }
 
 
@@ -17,9 +17,9 @@ void UtilityAIArea3DSearchSpace::_bind_methods() {
 
     ADD_SUBGROUP("Configuration","");
 
-    ClassDB::bind_method(D_METHOD("set_area3d_nodepath", "area3d_nodepath"), &UtilityAIArea3DSearchSpace::set_area3d_nodepath);
-    ClassDB::bind_method(D_METHOD("get_area3d_nodepath"), &UtilityAIArea3DSearchSpace::get_area3d_nodepath);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "area3d_nodepath", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Area3D"), "set_area3d_nodepath","get_area3d_nodepath");
+    ClassDB::bind_method(D_METHOD("set_area3d", "area3d"), &UtilityAIArea3DSearchSpace::set_area3d);
+    ClassDB::bind_method(D_METHOD("get_area3d"), &UtilityAIArea3DSearchSpace::get_area3d);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "area3d", PROPERTY_HINT_NODE_TYPE, "Area3D"), "set_area3d", "get_area3d");
 
     ClassDB::bind_method(D_METHOD("on_area_entered", "area"), &UtilityAIArea3DSearchSpace::on_area_entered);
     ClassDB::bind_method(D_METHOD("on_area_exited", "area"), &UtilityAIArea3DSearchSpace::on_area_exited);
@@ -59,13 +59,13 @@ void UtilityAIArea3DSearchSpace::on_area_exited(Area3D* area ) {
     
 // Getters and setters for attributes.
 
-void UtilityAIArea3DSearchSpace::set_area3d_nodepath( NodePath area3d_nodepath ) {
-    _area3d_nodepath = area3d_nodepath;
+void UtilityAIArea3DSearchSpace::set_area3d( Area3D* area3d ) {
+    _area3d = area3d;
 }
 
 
-NodePath UtilityAIArea3DSearchSpace::get_area3d_nodepath() const {
-    return _area3d_nodepath;
+Area3D* UtilityAIArea3DSearchSpace::get_area3d() const {
+    return _area3d;
 }
 
 
@@ -87,23 +87,20 @@ TypedArray<Node> UtilityAIArea3DSearchSpace::get_searchspace_nodes() const {
 
 
 void UtilityAIArea3DSearchSpace::_initialize_search_space() {
-    Node* node = get_node_or_null(_area3d_nodepath);
-    ERR_FAIL_COND_MSG( node == nullptr, "UtilityAIArea3DSearchSpace::_initialize_search_space() - Error, the nodepath for the Area3D has not been set.");
-    _area3d_node = godot::Object::cast_to<Area3D>(node);
-    ERR_FAIL_COND_MSG( _area3d_node == nullptr, "UtilityAIArea3DSearchSpace::_initialize_sensor() - Error, the node set as the Area3D is not of type Area3D.");
+    ERR_FAIL_COND_MSG( _area3d == nullptr, "UtilityAIArea3DSearchSpace::_initialize_search_space() - Error, the node for the Area3D has not been set.");
     
     // Connect to the area entered and exited signals.
-    Error error_visibility_volume_on_entered = _area3d_node->connect("area_entered", Callable(this, "on_area_entered"));
-    Error error_visibility_volume_on_exited  = _area3d_node->connect("area_exited", Callable(this, "on_area_exited"));
+    Error error_visibility_volume_on_entered = _area3d->connect("area_entered", Callable(this, "on_area_entered"));
+    Error error_visibility_volume_on_exited  = _area3d->connect("area_exited", Callable(this, "on_area_exited"));
 
 }
 
 
 void UtilityAIArea3DSearchSpace::_uninitialize_search_space() {
-    if( _area3d_node != nullptr ) {
-        _area3d_node->disconnect("area_entered", Callable(this, "on_area_entered"));
-        _area3d_node->disconnect("area_exited", Callable(this, "on_area_exited"));
+    if( _area3d != nullptr ) {
+        _area3d->disconnect("area_entered", Callable(this, "on_area_entered"));
+        _area3d->disconnect("area_exited", Callable(this, "on_area_exited"));
     }
-    _area3d_node = nullptr;
+    _area3d = nullptr;
 }
 

--- a/src/NodeQuerySystem/SearchSpaces/UtilityAIArea3DSearchSpace.h
+++ b/src/NodeQuerySystem/SearchSpaces/UtilityAIArea3DSearchSpace.h
@@ -10,8 +10,7 @@ class UtilityAIArea3DSearchSpace : public UtilityAINQSSearchSpaces {
     GDCLASS(UtilityAIArea3DSearchSpace, UtilityAINQSSearchSpaces)
 
 private:
-    NodePath _area3d_nodepath;
-    Area3D* _area3d_node;
+    Area3D* _area3d;
 
     TypedArray<Area3D> _intersecting_areas;
 protected:
@@ -28,8 +27,8 @@ public:
     
     // Getters and setters for attributes.
 
-    void set_area3d_nodepath( NodePath area3d_nodepath );
-    NodePath get_area3d_nodepath() const;
+    void set_area3d( Area3D* area3d );
+    Area3D* get_area3d() const;
 
     void set_intersecting_areas( TypedArray<Area3D> intersecting_areas );
     TypedArray<Area3D> get_intersecting_areas() const;

--- a/src/NodeQuerySystem/SearchSpaces/UtilityAINodeChildrenSearchSpace.cpp
+++ b/src/NodeQuerySystem/SearchSpaces/UtilityAINodeChildrenSearchSpace.cpp
@@ -6,7 +6,7 @@ using namespace godot;
 
 
 UtilityAINodeChildrenSearchSpace::UtilityAINodeChildrenSearchSpace() {
-    _parent_node_path = "";
+    _parent_node = nullptr;
 }
 
 
@@ -16,14 +16,13 @@ UtilityAINodeChildrenSearchSpace::~UtilityAINodeChildrenSearchSpace() {
 
 
 void UtilityAINodeChildrenSearchSpace::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("set_parent_node_path", "parent_node_path"), &UtilityAINodeChildrenSearchSpace::set_parent_node_path);
-    ClassDB::bind_method(D_METHOD("get_parent_node_path"), &UtilityAINodeChildrenSearchSpace::get_parent_node_path);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "parent_node_path", PROPERTY_HINT_NONE), "set_parent_node_path","get_parent_node_path");
+    ClassDB::bind_method(D_METHOD("set_parent_node", "parent_node"), &UtilityAINodeChildrenSearchSpace::set_parent_node);
+    ClassDB::bind_method(D_METHOD("get_parent_node"), &UtilityAINodeChildrenSearchSpace::get_parent_node);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "parent_node", PROPERTY_HINT_NODE_TYPE, "Node"), "set_parent_node","get_parent_node");
 }
 
 
 void UtilityAINodeChildrenSearchSpace::_initialize_search_space() {
-    _parent_node = get_node_or_null(_parent_node_path);
 }
 
 void UtilityAINodeChildrenSearchSpace::_uninitialize_search_space() {
@@ -32,13 +31,13 @@ void UtilityAINodeChildrenSearchSpace::_uninitialize_search_space() {
 
 // Getters and setters.
 
-void UtilityAINodeChildrenSearchSpace::set_parent_node_path( NodePath parent_node_path ) {
-    _parent_node_path = parent_node_path;
+void UtilityAINodeChildrenSearchSpace::set_parent_node( Node* parent_node ) {
+    _parent_node = parent_node;
 }
 
 
-NodePath UtilityAINodeChildrenSearchSpace::get_parent_node_path() const {
-    return _parent_node_path;
+Node* UtilityAINodeChildrenSearchSpace::get_parent_node() const {
+    return _parent_node;
 }
 
 

--- a/src/NodeQuerySystem/SearchSpaces/UtilityAINodeChildrenSearchSpace.h
+++ b/src/NodeQuerySystem/SearchSpaces/UtilityAINodeChildrenSearchSpace.h
@@ -10,7 +10,6 @@ class UtilityAINodeChildrenSearchSpace : public UtilityAINQSSearchSpaces {
     GDCLASS(UtilityAINodeChildrenSearchSpace, UtilityAINQSSearchSpaces)
 
 private:
-    NodePath _parent_node_path;
     Node*   _parent_node;
 protected:
     static void _bind_methods();
@@ -23,8 +22,8 @@ public:
     
     
     // Getters and setters for attributes.
-    void set_parent_node_path( NodePath parent_node_path );
-    NodePath get_parent_node_path() const;
+    void set_parent_node( Node* parent );
+    Node* get_parent_node() const;
 
     virtual TypedArray<Node> get_searchspace_nodes() const override;
 

--- a/src/SpecialConsiderations/UtilityAICustomPropertyConsideration.cpp
+++ b/src/SpecialConsiderations/UtilityAICustomPropertyConsideration.cpp
@@ -10,9 +10,9 @@ using namespace godot;
 
 void UtilityAICustomPropertyConsideration::_bind_methods() {
 
-    ClassDB::bind_method(D_METHOD("set_node_with_property_nodepath", "node_with_property_nodepath"), &UtilityAICustomPropertyConsideration::set_node_with_property_nodepath);
-    ClassDB::bind_method(D_METHOD("get_node_with_property_nodepath"), &UtilityAICustomPropertyConsideration::get_node_with_property_nodepath);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_with_property_nodepath", PROPERTY_HINT_NONE), "set_node_with_property_nodepath","get_node_with_property_nodepath");
+    ClassDB::bind_method(D_METHOD("set_node_with_property", "node_with_property"), &UtilityAICustomPropertyConsideration::set_node_with_property);
+    ClassDB::bind_method(D_METHOD("get_node_with_property"), &UtilityAICustomPropertyConsideration::get_node_with_property);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "node_with_property", PROPERTY_HINT_NODE_TYPE, "Node"), "set_node_with_property", "get_node_with_property");
 
     ClassDB::bind_method(D_METHOD("set_property_name", "property_name"), &UtilityAICustomPropertyConsideration::set_property_name);
     ClassDB::bind_method(D_METHOD("get_property_name"), &UtilityAICustomPropertyConsideration::get_property_name);
@@ -51,11 +51,11 @@ Ref<Curve> UtilityAICustomPropertyConsideration::get_activation_curve() const {
     return _activation_curve;
 }
 
-void UtilityAICustomPropertyConsideration::set_node_with_property_nodepath( NodePath node_with_property_nodepath ) {
-    _node_with_property_nodepath = node_with_property_nodepath;
+void UtilityAICustomPropertyConsideration::set_node_with_property( Node* node_with_property ) {
+    _node_with_property = node_with_property;
 }
-NodePath UtilityAICustomPropertyConsideration::get_node_with_property_nodepath() const {
-    return _node_with_property_nodepath;
+Node* UtilityAICustomPropertyConsideration::get_node_with_property() const {
+    return _node_with_property;
 }
 
 void UtilityAICustomPropertyConsideration::set_property_max_value( double property_max_value ) {
@@ -103,7 +103,6 @@ void UtilityAICustomPropertyConsideration::_notification(int p_what) {
 
 void UtilityAICustomPropertyConsideration::initialize_consideration() {
     if( Engine::get_singleton()->is_editor_hint() ) return;
-    _node_with_property = get_node_or_null(_node_with_property_nodepath);
     if( _property_max_value != 0.0 ) {
         _one_over_property_max_value = _property_max_value;
     }

--- a/src/SpecialConsiderations/UtilityAICustomPropertyConsideration.h
+++ b/src/SpecialConsiderations/UtilityAICustomPropertyConsideration.h
@@ -10,7 +10,6 @@ class UtilityAICustomPropertyConsideration : public UtilityAIConsiderations {
     GDCLASS(UtilityAICustomPropertyConsideration, UtilityAIConsiderations )
 
 private:
-    NodePath    _node_with_property_nodepath;
     Node*       _node_with_property;
     StringName  _property_name;
     double      _property_max_value;    
@@ -30,8 +29,8 @@ public:
     void set_activation_curve( Ref<Curve> activation_curve );
     Ref<Curve> get_activation_curve() const;
 
-    void set_node_with_property_nodepath( NodePath node_with_property );
-    NodePath get_node_with_property_nodepath() const;
+    void set_node_with_property( Node* node_with_property );
+    Node* get_node_with_property() const;
 
     void set_property_max_value( double true_score_value );
     double get_property_max_value() const;

--- a/src/SpecialSensors/UtilityAIArea2DVisibilitySensor.h
+++ b/src/SpecialSensors/UtilityAIArea2DVisibilitySensor.h
@@ -10,8 +10,7 @@ class UtilityAIArea2DVisibilitySensor : public UtilityAISensor {
     GDCLASS(UtilityAIArea2DVisibilitySensor, UtilityAISensor )
 
 private:
-    NodePath _visibility_volume_nodepath;
-    Area2D* _visibility_volume_node;
+    Area2D* _visibility_volume;
 
     Vector2 _from_vector;
     Vector2 _offset_vector;
@@ -71,11 +70,8 @@ public:
     void set_offset_vector2( Vector2 offset );
     Vector2 get_offset_vector2() const;
 
-    void set_visibility_volume_nodepath( NodePath visibility_volume_nodepath );
-    NodePath get_visibility_volume_nodepath() const;
-
-    void set_visibility_volume_node( Area2D* node );
-    Area2D* get_visibility_volume_node() const;
+    void set_visibility_volume( Area2D* visibility_volume );
+    Area2D* get_visibility_volume() const;
 
     void set_do_occlusion_test( bool do_occlusion_test );
     bool get_do_occlusion_test() const;

--- a/src/SpecialSensors/UtilityAIArea3DVisibilitySensor.cpp
+++ b/src/SpecialSensors/UtilityAIArea3DVisibilitySensor.cpp
@@ -26,9 +26,9 @@ void UtilityAIArea3DVisibilitySensor::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset_vector", PROPERTY_HINT_NONE), "set_offset_vector","get_offset_vector");
 
 
-    ClassDB::bind_method(D_METHOD("set_visibility_volume_nodepath", "visibility_volume_nodepath"), &UtilityAIArea3DVisibilitySensor::set_visibility_volume_nodepath);
-    ClassDB::bind_method(D_METHOD("get_visibility_volume_nodepath"), &UtilityAIArea3DVisibilitySensor::get_visibility_volume_nodepath);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "visibility_volume_nodepath", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Area3D"), "set_visibility_volume_nodepath","get_visibility_volume_nodepath");
+    ClassDB::bind_method(D_METHOD("set_visibility_volume", "visibility_volume"), &UtilityAIArea3DVisibilitySensor::set_visibility_volume);
+    ClassDB::bind_method(D_METHOD("get_visibility_volume"), &UtilityAIArea3DVisibilitySensor::get_visibility_volume);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "visibility_volume", PROPERTY_HINT_NODE_TYPE, "Area3D"), "set_visibility_volume","get_visibility_volume");
     
     ClassDB::bind_method(D_METHOD("set_max_expected_entities_found", "max_expected_entities_found"), &UtilityAIArea3DVisibilitySensor::set_max_expected_entities_found);
     ClassDB::bind_method(D_METHOD("get_max_expected_entities_found"), &UtilityAIArea3DVisibilitySensor::get_max_expected_entities_found);
@@ -100,7 +100,7 @@ void UtilityAIArea3DVisibilitySensor::_bind_methods() {
 // Constructor and destructor.
 
 UtilityAIArea3DVisibilitySensor::UtilityAIArea3DVisibilitySensor() {
-    _visibility_volume_node = nullptr;
+    _visibility_volume = nullptr;
     _do_occlusion_test = true;
     _collision_mask = 1;
     _expected_number_of_areas_to_track = 16;
@@ -149,28 +149,25 @@ void UtilityAIArea3DVisibilitySensor::initialize_sensor() {
     //if( !get_is_active() ) return;
     if( Engine::get_singleton()->is_editor_hint() ) return;
 
-    Node* node = get_node_or_null(_visibility_volume_nodepath);
-    ERR_FAIL_COND_MSG( node == nullptr, "UtilityAIArea3DVisibilitySensor::initialize_sensor() - Error, the nodepath for the Area3D has not been set.");
-    _visibility_volume_node = godot::Object::cast_to<Area3D>(node);
-    ERR_FAIL_COND_MSG( _visibility_volume_node == nullptr, "UtilityAIArea3DVisibilitySensor::initialize_sensor() - Error, the node set as the Area3D is not of type Area3D.");
+    ERR_FAIL_COND_MSG( _visibility_volume == nullptr, "UtilityAIArea3DVisibilitySensor::initialize_sensor() - Error, the node set as the Area3D is not of type Area3D.");
     
     // Connect to the area entered and exited signals.
-    Error error_visibility_volume_on_entered = _visibility_volume_node->connect("area_entered", Callable(this, "on_area_entered"));
-    Error error_visibility_volume_on_exited  = _visibility_volume_node->connect("area_exited", Callable(this, "on_area_exited"));
+    Error error_visibility_volume_on_entered = _visibility_volume->connect("area_entered", Callable(this, "on_area_entered"));
+    Error error_visibility_volume_on_exited  = _visibility_volume->connect("area_exited", Callable(this, "on_area_exited"));
 }
 
 
 void UtilityAIArea3DVisibilitySensor::uninitialize_sensor() {
-    if( _visibility_volume_node != nullptr ) {
-        _visibility_volume_node->disconnect("area_entered", Callable(this, "on_area_entered"));
-        _visibility_volume_node->disconnect("area_exited", Callable(this, "on_area_exited"));
-        _visibility_volume_node = nullptr;
+    if( _visibility_volume != nullptr ) {
+        _visibility_volume->disconnect("area_entered", Callable(this, "on_area_entered"));
+        _visibility_volume->disconnect("area_exited", Callable(this, "on_area_exited"));
+        _visibility_volume = nullptr;
     }
 }
 
 
 double UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
-    if( _visibility_volume_node == nullptr ) {
+    if( _visibility_volume == nullptr ) {
         return get_sensor_value();
     }
 
@@ -179,7 +176,7 @@ double UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
     PhysicsDirectSpaceState3D *dss = nullptr;
     
     if( _do_occlusion_test ) {
-        dss = PhysicsServer3D::get_singleton()->space_get_direct_state(PhysicsServer3D::get_singleton()->area_get_space(_visibility_volume_node->get_rid()));
+        dss = PhysicsServer3D::get_singleton()->space_get_direct_state(PhysicsServer3D::get_singleton()->area_get_space(_visibility_volume->get_rid()));
         //PhysicsDirectSpaceState3D *dss = PhysicsServer3D::get_singleton()->space_get_direct_state(w3d->get_space());
         ERR_FAIL_NULL_V(dss, get_sensor_value());
     }
@@ -328,23 +325,13 @@ Vector3 UtilityAIArea3DVisibilitySensor::get_offset_vector3() const {
 }
 
 
-void UtilityAIArea3DVisibilitySensor::set_visibility_volume_nodepath( NodePath area3d_nodepath ) {
-    _visibility_volume_nodepath = area3d_nodepath;
+void UtilityAIArea3DVisibilitySensor::set_visibility_volume( Area3D* visibility_volume ) {
+    _visibility_volume = visibility_volume;
 }
 
 
-NodePath UtilityAIArea3DVisibilitySensor::get_visibility_volume_nodepath() const {
-    return _visibility_volume_nodepath;
-}
-
-
-void UtilityAIArea3DVisibilitySensor::set_visibility_volume_node( Area3D* node ) {
-    _visibility_volume_node = node;
-}
-
-
-Area3D* UtilityAIArea3DVisibilitySensor::get_visibility_volume_node() const {
-    return _visibility_volume_node;
+Area3D* UtilityAIArea3DVisibilitySensor::get_visibility_volume() const {
+    return _visibility_volume;
 }
 
 

--- a/src/SpecialSensors/UtilityAIArea3DVisibilitySensor.h
+++ b/src/SpecialSensors/UtilityAIArea3DVisibilitySensor.h
@@ -10,8 +10,7 @@ class UtilityAIArea3DVisibilitySensor : public UtilityAISensor {
     GDCLASS(UtilityAIArea3DVisibilitySensor, UtilityAISensor )
 
 private:
-    NodePath _visibility_volume_nodepath;
-    Area3D* _visibility_volume_node;
+    Area3D* _visibility_volume;
 
     Vector3 _from_vector;
     Vector3 _offset_vector;
@@ -69,11 +68,8 @@ public:
     void set_offset_vector3( Vector3 offset );
     Vector3 get_offset_vector3() const;
 
-    void set_visibility_volume_nodepath( NodePath visibility_volume_nodepath );
-    NodePath get_visibility_volume_nodepath() const;
-
-    void set_visibility_volume_node( Area3D* node );
-    Area3D* get_visibility_volume_node() const;
+    void set_visibility_volume( Area3D* visibility_volume );
+    Area3D* get_visibility_volume() const;
 
     void set_do_occlusion_test( bool do_occlusion_test );
     bool get_do_occlusion_test() const;

--- a/src/UtilityAIConsideration.cpp
+++ b/src/UtilityAIConsideration.cpp
@@ -11,9 +11,9 @@ using namespace godot;
 
 void UtilityAIConsideration::_bind_methods() {
 
-    ClassDB::bind_method(D_METHOD("set_input_sensor_node_path", "input_sensor_node_path"), &UtilityAIConsideration::set_input_sensor_node_path);
-    ClassDB::bind_method(D_METHOD("get_input_sensor_node_path"), &UtilityAIConsideration::get_input_sensor_node_path);
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "input_sensor_node_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "UtilityAISensors"), "set_input_sensor_node_path", "get_input_sensor_node_path");
+    ClassDB::bind_method(D_METHOD("set_input_sensor", "input_sensor"), &UtilityAIConsideration::set_input_sensor);
+    ClassDB::bind_method(D_METHOD("get_input_sensor"), &UtilityAIConsideration::get_input_sensor);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "input_sensor", PROPERTY_HINT_NODE_TYPE, "UtilityAISensors"), "set_input_sensor", "get_input_sensor");
 
     ClassDB::bind_method(D_METHOD("set_activation_curve", "activation_curve"), &UtilityAIConsideration::set_activation_curve);
     ClassDB::bind_method(D_METHOD("get_activation_curve"), &UtilityAIConsideration::get_activation_curve);
@@ -24,7 +24,6 @@ void UtilityAIConsideration::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "activation_input_value", PROPERTY_HINT_RANGE, "0.0,1.0,or_less,or_greater"), "set_activation_input_value","get_activation_input_value");
 
     ClassDB::bind_method(D_METHOD("sample_activation_curve", "input_value"), &UtilityAIConsideration::sample_activation_curve);
-    ClassDB::bind_method(D_METHOD("initialize_consideration"), &UtilityAIConsideration::initialize_consideration);
 }
 
 
@@ -45,17 +44,12 @@ UtilityAIConsideration::~UtilityAIConsideration() {
 
 // Getters and Setters.
 
-UtilityAISensors* UtilityAIConsideration::get_input_sensor_node() const {
+void UtilityAIConsideration::set_input_sensor( UtilityAISensors* input_sensor ) {
+    _input_sensor = input_sensor;
+}
+
+UtilityAISensors* UtilityAIConsideration::get_input_sensor() const {
     return _input_sensor;
-}
-
-
-void UtilityAIConsideration::set_input_sensor_node_path( NodePath input_sensor_node_path ) {
-    _input_sensor_node_path = input_sensor_node_path;
-}
-
-NodePath UtilityAIConsideration::get_input_sensor_node_path() const {
-    return _input_sensor_node_path;
 }
 
 
@@ -76,12 +70,6 @@ double UtilityAIConsideration::get_activation_input_value() const {
     return _activation_input_value;
 }
 
-// Godot virtuals.
-
-void UtilityAIConsideration::_ready() {
-    initialize_consideration();
-}
-
 /**
 void UtilityAIConsideration::_notification(int p_what) {
 	switch (p_what) {
@@ -96,29 +84,6 @@ void UtilityAIConsideration::_notification(int p_what) {
 /**/
 
 // Handling functions.
-
-void UtilityAIConsideration::initialize_consideration() {
-    if( !get_is_active() ) return;
-    if( Engine::get_singleton()->is_editor_hint() ) return;
-
-    _has_custom_evaluation_method = has_method("eval");
-    if( _input_sensor_node_path.is_empty()) {
-        return;
-    }
-    Node* node = get_node_or_null(_input_sensor_node_path);
-    // As this is not always needed, error out without a message.
-    if( node == nullptr ) {
-        return;
-    } 
-
-    UtilityAISensors* sensor = godot::Object::cast_to<UtilityAISensors>(node);
-    if( sensor == nullptr ) {
-        return;
-    }
-    _input_sensor = sensor;
-    //ERR_FAIL_COND_MSG( _input_sensor == nullptr, "UtilityAIConsideration::intialize_consideration(): Error, the assigned node's type was not a UtilityAISensors type for UtilityAIConsideration '" + get_name() + "'.");
-}
-    
 
 double UtilityAIConsideration::evaluate() { 
     if( !get_is_active() ) return 0.0;

--- a/src/UtilityAIConsideration.h
+++ b/src/UtilityAIConsideration.h
@@ -18,7 +18,6 @@ protected:
     static void _bind_methods();
 
     UtilityAISensors* _input_sensor;
-    NodePath          _input_sensor_node_path;
     Ref<Curve>        _activation_curve;
     double            _activation_input_value;
     bool              _has_custom_evaluation_method;
@@ -31,10 +30,8 @@ public:
     
     // Getters and setters for attributes.
 
-    virtual UtilityAISensors* get_input_sensor_node() const;
-
-    void set_input_sensor_node_path( NodePath input_sensor_node_path );
-    NodePath get_input_sensor_node_path() const;
+    void set_input_sensor( UtilityAISensors* input_sensor );
+    virtual UtilityAISensors* get_input_sensor() const;
 
     void set_activation_curve( Ref<Curve> activation_curve );
     Ref<Curve> get_activation_curve() const;
@@ -44,12 +41,10 @@ public:
 
             
     // Godot virtuals.
-    void _ready();
     //void _notification( int p_what );
    
     // Handling functions.
     
-    void initialize_consideration();
     virtual double evaluate() override;
     virtual double sample_activation_curve( double input_value ) const;
 };


### PR DESCRIPTION
Across the project, NodePaths were used instead of just Nodes. Although GDExtension doesn't make it obvious, there is a way to export Node.