### PR TITLE
Get compiling with latest Godot 4.1 commit

### DIFF
--- a/src/node_query_system/search_criteria/custom.cpp
+++ b/src/node_query_system/search_criteria/custom.cpp
@@ -2,6 +2,9 @@
 
 using namespace godot;
 
+void UtilityAICustomSearchCriterion::_bind_methods() {
+
+}
 
 
 UtilityAICustomSearchCriterion::UtilityAICustomSearchCriterion() {

--- a/src/node_query_system/search_criteria/custom.h
+++ b/src/node_query_system/search_criteria/custom.h
@@ -1,5 +1,5 @@
 #ifndef UtilityAICustomSearchCriterion_H_INCLUDED
-#define UtilityAICustomSearchCriterion_H_INCLUDED 
+#define UtilityAICustomSearchCriterion_H_INCLUDED
 
 #include "nqs.h"
 
@@ -9,15 +9,15 @@ class UtilityAICustomSearchCriterion : public UtilityAINQSSearchCriteria {
     GDCLASS(UtilityAICustomSearchCriterion, UtilityAINQSSearchCriteria)
 
 private:
-    
+
 protected:
-    //static void _bind_methods();
+    static void _bind_methods();
 
 public:
     UtilityAICustomSearchCriterion();
     ~UtilityAICustomSearchCriterion();
-    
-    
+
+
     // Getters and setters for attributes.
 
 
@@ -30,4 +30,4 @@ public:
 }
 
 
-#endif 
+#endif

--- a/src/state_tree/node.cpp
+++ b/src/state_tree/node.cpp
@@ -21,15 +21,20 @@ using namespace godot;
     //ClassDB::bind_method(D_METHOD("tick", "user_data", "delta"), &UtilityAISTSelector::tick);
 //}
 
+void UtilityAISTNode::_bind_methods() {
+
+}
+
 
 // Constructor and destructor.
 
 UtilityAISTNode::UtilityAISTNode() {
-    
+
 }
 
 
 UtilityAISTNode::~UtilityAISTNode() {
+
 }
 
 
@@ -43,7 +48,7 @@ UtilityAISTNode::~UtilityAISTNode() {
 // Handling functions.
 
 /**
-UtilityAISTNodes* UtilityAISTSelector::_tick(Variant user_data, double delta) { 
+UtilityAISTNodes* UtilityAISTSelector::_tick(Variant user_data, double delta) {
 
     // The selector will only consider the state tree nodes.
     UtilityAISTNodes* result_state = nullptr;

--- a/src/state_tree/node.h
+++ b/src/state_tree/node.h
@@ -1,5 +1,5 @@
 #ifndef UtilityAISTSelector_H_INCLUDED
-#define UtilityAISTSelector_H_INCLUDED 
+#define UtilityAISTSelector_H_INCLUDED
 
 #include "nodes.h"
 //#include <godot_cpp/classes/node.hpp>
@@ -15,14 +15,15 @@ private:
 
 
 protected:
+    static void _bind_methods();
 
 public:
     UtilityAISTNode();
     ~UtilityAISTNode();
-    
+
 };
 
 }
 
 
-#endif 
+#endif


### PR DESCRIPTION
This repo isn't compiling at the moment. It's giving the following error:

```powershell
$ scons
scons: Reading SConscript files ...
NameError: name 'BoolVariable' is not defined:
  File "C:\\Utility_AI\SConstruct", line 5:
    env = SConscript("godot-cpp/SConstruct")
  File "C:\Users\me\scoop\apps\scons\4.8.0\scons-local-4.8.0\SCons\Script\SConscript.py", line 684:
    return method(*args, **kw)
  File "C:\Users\me\scoop\apps\scons\4.8.0\scons-local-4.8.0\SCons\Script\SConscript.py", line 620:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\Users\me\scoop\apps\scons\4.8.0\scons-local-4.8.0\SCons\Script\SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "C:\\Utility_AI\godot-cpp\SConstruct", line 36:
    cpp_tool.options(opts, env)
  File "C:\\Utility_AI\godot-cpp\tools\godotcpp.py", line 182:
    tool.options(opts)
  File "C:\\Utility_AI\godot-cpp\tools\linux.py", line 6:
    opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler - only effective when targeting Linux", False))
```

To fix that I updated the `godot-cpp` submodule to the latest 4.1 commit.

After that I was getting the following error:

```powershell
$ scons
Compiling shared src\state_tree\node.cpp ...
Linking Static Library godot-cpp\bin\libgodot-cpp.windows.template_debug.x86_64.lib ...
godot-cpp\include\godot_cpp/core/class_db.hpp(177): error C2338: static_assert failed: 'Class must declare 'static void _bind_methods'.'
godot-cpp\include\godot_cpp/core/class_db.hpp(177): note: the template instantiation context (the oldest one first) is
src\register_types.cpp(222): note: see reference to function template instantiation 'void godot::ClassDB::register_class<godot::UtilityAISTNode>(bool)' being compiled
godot-cpp\include\godot_cpp/core/class_db.hpp(226): note: see reference to function template instantiation 'void godot::ClassDB::_register_class<T,false>(bool)' being compiled
        with
        [
            T=godot::UtilityAISTNode
        ]
scons: *** [src\register_types.windows.template_debug.x86_64.obj] Error 2
scons: building terminated because of errors.
```

To fix that I just needed to add an empty `_bind_methods` definition to the two classes missing it.