### PR TITLE
Ignore demo project imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ dkms.conf
 
 # Godot-specific ignores
 .import/
+*.import
 export.cfg
 export_presets.cfg
 


### PR DESCRIPTION
When opening the demo project to test changes, a million .import files are created which all want to get added to git. This PR ignores them as we don't want them in the repo.