### PR TITLE
Add bodies support to UtilityAIArea3DVisibilitySensor

### DIFF
--- a/src/agent_behaviours/sensors/area3d_visibility.cpp
+++ b/src/agent_behaviours/sensors/area3d_visibility.cpp
@@ -2,7 +2,6 @@
 
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/classes/engine.hpp>
-#include <godot_cpp/classes/node3d.hpp>
 #include <godot_cpp/classes/physics_server3d.hpp>
 #include <godot_cpp/classes/physics_direct_space_state3d.hpp>
 #include <godot_cpp/classes/physics_ray_query_parameters3d.hpp>
@@ -15,12 +14,12 @@ using namespace godot;
 
 void UtilityAIArea3DVisibilitySensor::_bind_methods() {
 
-    ADD_SUBGROUP("Configuration","");
+    ADD_GROUP("Configuration","");
 
     ClassDB::bind_method(D_METHOD("set_use_owner_global_position", "use_owner_global_position"), &UtilityAIArea3DVisibilitySensor::set_use_owner_global_position);
     ClassDB::bind_method(D_METHOD("get_use_owner_global_position"), &UtilityAIArea3DVisibilitySensor::get_use_owner_global_position);
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_owner_global_position", PROPERTY_HINT_NONE), "set_use_owner_global_position","get_use_owner_global_position");
-    
+
     ClassDB::bind_method(D_METHOD("set_offset_vector", "offset_vector"), &UtilityAIArea3DVisibilitySensor::set_offset_vector3);
     ClassDB::bind_method(D_METHOD("get_offset_vector"), &UtilityAIArea3DVisibilitySensor::get_offset_vector3);
     ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "offset_vector", PROPERTY_HINT_NONE), "set_offset_vector","get_offset_vector");
@@ -29,14 +28,14 @@ void UtilityAIArea3DVisibilitySensor::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_visibility_volume", "visibility_volume"), &UtilityAIArea3DVisibilitySensor::set_visibility_volume);
     ClassDB::bind_method(D_METHOD("get_visibility_volume"), &UtilityAIArea3DVisibilitySensor::get_visibility_volume);
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "visibility_volume", PROPERTY_HINT_NODE_TYPE, "Area3D"), "set_visibility_volume","get_visibility_volume");
-    
+
     ClassDB::bind_method(D_METHOD("set_max_expected_entities_found", "max_expected_entities_found"), &UtilityAIArea3DVisibilitySensor::set_max_expected_entities_found);
     ClassDB::bind_method(D_METHOD("get_max_expected_entities_found"), &UtilityAIArea3DVisibilitySensor::get_max_expected_entities_found);
     ADD_PROPERTY(PropertyInfo(Variant::INT, "max_expected_entities_found", PROPERTY_HINT_RANGE, "1,32,or_greater"), "set_max_expected_entities_found","get_max_expected_entities_found");
 
 
-    ADD_SUBGROUP("Occlusion","");
-    
+    ADD_GROUP("Occlusion","");
+
     ClassDB::bind_method(D_METHOD("set_do_occlusion_test", "do_occlusion_test"), &UtilityAIArea3DVisibilitySensor::set_do_occlusion_test);
     ClassDB::bind_method(D_METHOD("get_do_occlusion_test"), &UtilityAIArea3DVisibilitySensor::get_do_occlusion_test);
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "do_occlusion_test", PROPERTY_HINT_NONE), "set_do_occlusion_test","get_do_occlusion_test");
@@ -55,8 +54,10 @@ void UtilityAIArea3DVisibilitySensor::_bind_methods() {
 
     ClassDB::bind_method(D_METHOD("on_area_entered", "area"), &UtilityAIArea3DVisibilitySensor::on_area_entered);
     ClassDB::bind_method(D_METHOD("on_area_exited", "area"), &UtilityAIArea3DVisibilitySensor::on_area_exited);
+    ClassDB::bind_method(D_METHOD("on_body_entered", "body"), &UtilityAIArea3DVisibilitySensor::on_body_entered);
+    ClassDB::bind_method(D_METHOD("on_body_exited", "body"), &UtilityAIArea3DVisibilitySensor::on_body_exited);
 
-    ADD_SUBGROUP("Debugging","");
+    ADD_GROUP("Debugging","");
 
     ClassDB::bind_method(D_METHOD("set_from_vector", "from_vector"), &UtilityAIArea3DVisibilitySensor::set_from_vector3);
     ClassDB::bind_method(D_METHOD("get_from_vector"), &UtilityAIArea3DVisibilitySensor::get_from_vector3);
@@ -65,6 +66,8 @@ void UtilityAIArea3DVisibilitySensor::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_num_entities_found", "num_entities_found"), &UtilityAIArea3DVisibilitySensor::set_num_entities_found);
     ClassDB::bind_method(D_METHOD("get_num_entities_found"), &UtilityAIArea3DVisibilitySensor::get_num_entities_found);
     ADD_PROPERTY(PropertyInfo(Variant::INT, "num_entities_found", PROPERTY_HINT_RANGE, "0,32,or_greater"), "set_num_entities_found","get_num_entities_found");
+
+    ADD_SUBGROUP("Areas", "");
 
     ClassDB::bind_method(D_METHOD("set_closest_intersecting_area_index", "closest_intersecting_area_index"), &UtilityAIArea3DVisibilitySensor::set_closest_intersecting_area_index);
     ClassDB::bind_method(D_METHOD("get_closest_intersecting_area_index"), &UtilityAIArea3DVisibilitySensor::get_closest_intersecting_area_index);
@@ -90,9 +93,31 @@ void UtilityAIArea3DVisibilitySensor::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_squared_distances_to_unoccluded_areas"), &UtilityAIArea3DVisibilitySensor::get_squared_distances_to_unoccluded_areas);
     ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "squared_distances_to_unoccluded_areas", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, "float")), "set_squared_distances_to_unoccluded_areas","get_squared_distances_to_unoccluded_areas");
 
-    //ClassDB::bind_method(D_METHOD("set_unoccluded_bodies", "unoccluded_bodies"), &UtilityAIArea3DVisibilitySensor::set_unoccluded_bodies);
-    //ClassDB::bind_method(D_METHOD("get_unoccluded_bodies"), &UtilityAIArea3DVisibilitySensor::get_unoccluded_bodies);
-    //ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "unoccluded_bodies", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, "Node3D")), "set_unoccluded_bodies","get_unoccluded_bodies");
+    ADD_SUBGROUP("Bodies", "");
+
+    ClassDB::bind_method(D_METHOD("set_closest_intersecting_body_index", "closest_intersecting_body_index"), &UtilityAIArea3DVisibilitySensor::set_closest_intersecting_body_index);
+    ClassDB::bind_method(D_METHOD("get_closest_intersecting_body_index"), &UtilityAIArea3DVisibilitySensor::get_closest_intersecting_body_index);
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "closest_intersecting_body_index", PROPERTY_HINT_RANGE, "-1,32,or_greater"), "set_closest_intersecting_body_index","get_closest_intersecting_body_index");
+
+    ClassDB::bind_method(D_METHOD("set_intersecting_bodies", "intersecting_bodies"), &UtilityAIArea3DVisibilitySensor::set_intersecting_bodies);
+    ClassDB::bind_method(D_METHOD("get_intersecting_bodies"), &UtilityAIArea3DVisibilitySensor::get_intersecting_bodies);
+    ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "intersecting_bodies", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, "Node3D")), "set_intersecting_bodies","get_intersecting_bodies");
+
+    ClassDB::bind_method(D_METHOD("set_squared_distances_to_intersecting_bodies", "squared_distances_to_intersecting_bodies"), &UtilityAIArea3DVisibilitySensor::set_squared_distances_to_intersecting_bodies);
+    ClassDB::bind_method(D_METHOD("get_squared_distances_to_intersecting_bodies"), &UtilityAIArea3DVisibilitySensor::get_squared_distances_to_intersecting_bodies);
+    ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "squared_distances_to_intersecting_bodies", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, "float")), "set_squared_distances_to_intersecting_bodies","get_squared_distances_to_intersecting_bodies");
+
+    ClassDB::bind_method(D_METHOD("set_closest_unoccluded_body_index", "closest_unoccluded_body_index"), &UtilityAIArea3DVisibilitySensor::set_closest_unoccluded_body_index);
+    ClassDB::bind_method(D_METHOD("get_closest_unoccluded_body_index"), &UtilityAIArea3DVisibilitySensor::get_closest_unoccluded_body_index);
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "closest_unoccluded_body_index", PROPERTY_HINT_RANGE, "-1,32,or_greater"), "set_closest_unoccluded_body_index","get_closest_unoccluded_body_index");
+
+    ClassDB::bind_method(D_METHOD("set_unoccluded_bodies", "unoccluded_bodies"), &UtilityAIArea3DVisibilitySensor::set_unoccluded_bodies);
+    ClassDB::bind_method(D_METHOD("get_unoccluded_bodies"), &UtilityAIArea3DVisibilitySensor::get_unoccluded_bodies);
+    ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "unoccluded_bodies", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, "Node3D")), "set_unoccluded_bodies","get_unoccluded_bodies");
+
+    ClassDB::bind_method(D_METHOD("set_squared_distances_to_unoccluded_bodies", "squared_distances_to_unoccluded_bodies"), &UtilityAIArea3DVisibilitySensor::set_squared_distances_to_unoccluded_bodies);
+    ClassDB::bind_method(D_METHOD("get_squared_distances_to_unoccluded_bodies"), &UtilityAIArea3DVisibilitySensor::get_squared_distances_to_unoccluded_bodies);
+    ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "squared_distances_to_unoccluded_bodies", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, "float")), "set_squared_distances_to_unoccluded_bodies","get_squared_distances_to_unoccluded_bodies");
 
 }
 
@@ -110,10 +135,12 @@ UtilityAIArea3DVisibilitySensor::UtilityAIArea3DVisibilitySensor() {
     _one_over_max_expected_entities_found = 1.0f / ((float)_max_expected_entities_found);
 
     _unoccluded_areas.resize(_expected_number_of_areas_to_track);
-    //_unoccluded_bodies.resize(_expected_number_of_bodies_to_track);
+    _unoccluded_bodies.resize(_expected_number_of_bodies_to_track);
 
     _closest_intersecting_area_index = -1;
+    _closest_intersecting_body_index = -1;
     _closest_unoccluded_area_index = -1;
+    _closest_unoccluded_body_index = -1;
 
     _use_owner_global_position = false;
 }
@@ -157,10 +184,12 @@ void UtilityAIArea3DVisibilitySensor::initialize_sensor() {
     if( Engine::get_singleton()->is_editor_hint() ) return;
 
     ERR_FAIL_COND_MSG( _visibility_volume == nullptr, "UtilityAIArea3DVisibilitySensor::initialize_sensor() - Error, the visibility volume is not set.");
-    
+
     // Connect to the area entered and exited signals.
-    Error error_visibility_volume_on_entered = _visibility_volume->connect("area_entered", Callable(this, "on_area_entered"));
-    Error error_visibility_volume_on_exited  = _visibility_volume->connect("area_exited", Callable(this, "on_area_exited"));
+    Error error_visibility_volume_on_area_entered = _visibility_volume->connect("area_entered", Callable(this, "on_area_entered"));
+    Error error_visibility_volume_on_area_exited  = _visibility_volume->connect("area_exited", Callable(this, "on_area_exited"));
+    Error error_visibility_volume_on_body_entered = _visibility_volume->connect("body_entered", Callable(this, "on_body_entered"));
+    Error error_visibility_volume_on_body_exited  = _visibility_volume->connect("body_exited", Callable(this, "on_body_exited"));
 }
 
 
@@ -169,6 +198,8 @@ void UtilityAIArea3DVisibilitySensor::uninitialize_sensor() {
     if( _visibility_volume != nullptr ) {
         _visibility_volume->disconnect("area_entered", Callable(this, "on_area_entered"));
         _visibility_volume->disconnect("area_exited", Callable(this, "on_area_exited"));
+        _visibility_volume->disconnect("body_entered", Callable(this, "on_body_entered"));
+        _visibility_volume->disconnect("body_exited", Callable(this, "on_body_exited"));
         _visibility_volume = nullptr;
     }
 }
@@ -190,7 +221,7 @@ float UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
     //Ref<World3D> w3d = _visibility_volume_node->get_world_3d();
     //ERR_FAIL_COND_V(w3d.is_null(), get_sensor_value());
     PhysicsDirectSpaceState3D *dss = nullptr;
-    
+
     if( _do_occlusion_test ) {
         dss = PhysicsServer3D::get_singleton()->space_get_direct_state(PhysicsServer3D::get_singleton()->area_get_space(_visibility_volume->get_rid()));
         //PhysicsDirectSpaceState3D *dss = PhysicsServer3D::get_singleton()->space_get_direct_state(w3d->get_space());
@@ -209,13 +240,21 @@ float UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
     _num_entities_found = 0;
     _closest_intersecting_area_index = -1;
     _closest_unoccluded_area_index = -1;
+    _closest_intersecting_body_index = -1;
+    _closest_unoccluded_body_index = -1;
     float closest_intersecting_area_distance = 0.0f;
     float closest_unoccluded_area_distance = 0.0f;
+    float closest_intersecting_body_distance = 0.0f;
+    float closest_unoccluded_body_distance = 0.0f;
     int   found_unoccluded_areas = 0;
+    int   found_unoccluded_bodies = 0;
     Vector3 zero_vector = Vector3();
     _unoccluded_areas.clear();
+    _unoccluded_bodies.clear();
     _squared_distances_to_unoccluded_areas.clear();
     _squared_distances_to_intersecting_areas.clear();
+    _squared_distances_to_unoccluded_bodies.clear();
+    _squared_distances_to_intersecting_bodies.clear();
     for( int i = 0; i < _intersecting_areas.size(); ++i ) {
         Area3D* area = godot::Object::cast_to<Area3D>(_intersecting_areas[i]);
         if( area == nullptr ) {
@@ -235,14 +274,14 @@ float UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
             closest_intersecting_area_distance = distance_squared;
         }
 
-        if( _do_occlusion_test ) {    
+        if( _do_occlusion_test ) {
             Vector3 to = area_position;
             if (to == zero_vector) {
-                continue; 
+                continue;
             }
-            Ref<PhysicsRayQueryParameters3D> params = godot::PhysicsRayQueryParameters3D::create(offset_from_vector, 
-                                                                                                 to, 
-                                                                                                 _collision_mask, 
+            Ref<PhysicsRayQueryParameters3D> params = godot::PhysicsRayQueryParameters3D::create(offset_from_vector,
+                                                                                                 to,
+                                                                                                 _collision_mask,
                                                                                                  _occlusion_test_exclusion_list);
             //(const Vector3 &from, const Vector3 &to, uint32_t collision_mask = 4294967295, const TypedArray<RID> &exclude = {})
             params->set_collide_with_bodies(true);
@@ -265,9 +304,59 @@ float UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
         } else {
             ++_num_entities_found;
         }
-
-        
     }//endfor entered areas.
+
+    for( int i = 0; i < _intersecting_bodies.size(); ++i ) {
+        Node3D* body = godot::Object::cast_to<Node3D>(_intersecting_bodies[i]);
+        if( body == nullptr ) {
+            continue;
+        }
+        Vector3 body_position = body->get_global_position();
+
+        // Calculate the distance to the area.
+        Vector3 from_to = body_position - offset_from_vector;
+        float distance_squared = from_to.length_squared();
+        _squared_distances_to_intersecting_bodies.push_back(distance_squared);
+        if( _closest_intersecting_body_index == -1 ) {
+            _closest_intersecting_body_index = i;
+            closest_intersecting_body_distance = distance_squared;
+        } else if( closest_intersecting_body_distance > distance_squared ) {
+            _closest_intersecting_body_index = i;
+            closest_intersecting_body_distance = distance_squared;
+        }
+
+        if( _do_occlusion_test ) {
+            Vector3 to = body_position;
+            if (to == zero_vector) {
+                continue;
+            }
+            Ref<PhysicsRayQueryParameters3D> params = godot::PhysicsRayQueryParameters3D::create(offset_from_vector,
+                                                                                                 to,
+                                                                                                 _collision_mask,
+                                                                                                 _occlusion_test_exclusion_list);
+            //(const Vector3 &from, const Vector3 &to, uint32_t collision_mask = 4294967295, const TypedArray<RID> &exclude = {})
+            params->set_collide_with_bodies(true);
+            params->set_collide_with_areas(false);
+            //params->set_block_signals(true);
+            Dictionary results = dss->intersect_ray( params );
+            if( results.is_empty() ) {
+                _unoccluded_bodies.push_back(body);
+                _squared_distances_to_unoccluded_bodies.push_back(distance_squared);
+                if( _closest_unoccluded_body_index == -1 ) {
+                    _closest_unoccluded_body_index = found_unoccluded_areas;
+                    closest_unoccluded_body_distance = distance_squared;
+                } else if( closest_unoccluded_body_distance > distance_squared ) {
+                    _closest_unoccluded_body_index = found_unoccluded_areas;
+                    closest_unoccluded_body_distance = distance_squared;
+                }
+                ++found_unoccluded_bodies;
+                ++_num_entities_found;
+            }
+        } else {
+            ++_num_entities_found;
+        }
+    }//endfor entered bodies.
+
     /**
     if( get_use_absolute_value() ) {
         set_sensor_value(((float)_num_entities_found));
@@ -286,9 +375,21 @@ void UtilityAIArea3DVisibilitySensor::on_area_entered(Area3D* area ) {
     }
     if( _intersecting_areas.has(area) ) {
         return;
-    }   
+    }
     _has_sensor_value_changed = true;
     _intersecting_areas.push_back(area);
+}
+
+void UtilityAIArea3DVisibilitySensor::on_body_entered(Node3D* body ) {
+    //WARN_PRINT("Body entered!");
+    if( body == nullptr ) {
+        return;
+    }
+    if( _intersecting_bodies.has(body) ) {
+        return;
+    }
+    _has_sensor_value_changed = true;
+    _intersecting_bodies.push_back(body);
 }
 
 
@@ -308,10 +409,26 @@ void UtilityAIArea3DVisibilitySensor::on_area_exited(Area3D* area ) {
     _intersecting_areas.remove_at(index);
 }
 
+void UtilityAIArea3DVisibilitySensor::on_body_exited(Node3D* body ) {
+    //WARN_PRINT("body exited");
+    if( body == nullptr ) {
+        return;
+    }
+    if( !_intersecting_bodies.has(body ) ) {
+        return;
+    }
+    int index = _intersecting_bodies.find(body);
+    if( index < 0 ) {
+        return;
+    }
+    _has_sensor_value_changed = true;
+    _intersecting_bodies.remove_at(index);
+}
+
 
 // Getters and Setters.
 
-// Configuration values. 
+// Configuration values.
 
 void UtilityAIArea3DVisibilitySensor::set_use_owner_global_position( bool use_owner_global_position ) {
     _has_sensor_value_changed = _has_sensor_value_changed || ( _use_owner_global_position != use_owner_global_position );
@@ -434,9 +551,18 @@ void UtilityAIArea3DVisibilitySensor::set_closest_intersecting_area_index( int c
     _closest_intersecting_area_index = closest_intersecting_area_index;
 }
 
+void UtilityAIArea3DVisibilitySensor::set_closest_intersecting_body_index( int closest_intersecting_body_index ) {
+    _has_sensor_value_changed = _has_sensor_value_changed || ( _closest_intersecting_body_index != closest_intersecting_body_index );
+    _closest_intersecting_body_index = closest_intersecting_body_index;
+}
+
 
 int  UtilityAIArea3DVisibilitySensor::get_closest_intersecting_area_index() const {
     return _closest_intersecting_area_index;
+}
+
+int  UtilityAIArea3DVisibilitySensor::get_closest_intersecting_body_index() const {
+    return _closest_intersecting_body_index;
 }
 
 
@@ -445,9 +571,18 @@ void UtilityAIArea3DVisibilitySensor::set_closest_unoccluded_area_index( int clo
     _closest_unoccluded_area_index = closest_unoccluded_area_index;
 }
 
+void UtilityAIArea3DVisibilitySensor::set_closest_unoccluded_body_index( int closest_unoccluded_body_index ) {
+    _has_sensor_value_changed = _has_sensor_value_changed || ( _closest_unoccluded_body_index != closest_unoccluded_body_index );
+    _closest_unoccluded_body_index = closest_unoccluded_body_index;
+}
+
 
 int  UtilityAIArea3DVisibilitySensor::get_closest_unoccluded_area_index() const {
     return _closest_unoccluded_area_index;
+}
+
+int  UtilityAIArea3DVisibilitySensor::get_closest_unoccluded_body_index() const {
+    return _closest_unoccluded_body_index;
 }
 
 
@@ -456,9 +591,18 @@ void UtilityAIArea3DVisibilitySensor::set_intersecting_areas( TypedArray<Area3D>
     _intersecting_areas = intersecting_areas;
 }
 
+void UtilityAIArea3DVisibilitySensor::set_intersecting_bodies( TypedArray<Node3D> intersecting_bodies ) {
+    _has_sensor_value_changed = _has_sensor_value_changed || (_intersecting_bodies != intersecting_bodies);
+    _intersecting_bodies = intersecting_bodies;
+}
+
 
 TypedArray<Area3D> UtilityAIArea3DVisibilitySensor::get_intersecting_areas() const {
     return _intersecting_areas;
+}
+
+TypedArray<Node3D> UtilityAIArea3DVisibilitySensor::get_intersecting_bodies() const {
+    return _intersecting_bodies;
 }
 
 
@@ -467,31 +611,36 @@ void UtilityAIArea3DVisibilitySensor::set_unoccluded_areas( TypedArray<Area3D> u
     _unoccluded_areas = unoccluded_areas;
 }
 
-
-TypedArray<Area3D> UtilityAIArea3DVisibilitySensor::get_unoccluded_areas() const {
-    return _unoccluded_areas;
-}
-
-
 void UtilityAIArea3DVisibilitySensor::set_unoccluded_bodies( TypedArray<Node3D> unoccluded_bodies ) {
     _has_sensor_value_changed = _has_sensor_value_changed || (_unoccluded_bodies != unoccluded_bodies);
     _unoccluded_bodies = unoccluded_bodies;
 }
 
 
+TypedArray<Area3D> UtilityAIArea3DVisibilitySensor::get_unoccluded_areas() const {
+    return _unoccluded_areas;
+}
+
 TypedArray<Node3D> UtilityAIArea3DVisibilitySensor::get_unoccluded_bodies() const {
     return _unoccluded_bodies;
 }
-
 
 void UtilityAIArea3DVisibilitySensor::set_squared_distances_to_intersecting_areas( TypedArray<float> squared_distances_to_intersecting_areas ) {
     _has_sensor_value_changed = _has_sensor_value_changed || (_squared_distances_to_intersecting_areas != squared_distances_to_intersecting_areas);
     _squared_distances_to_intersecting_areas = squared_distances_to_intersecting_areas;
 }
 
+void UtilityAIArea3DVisibilitySensor::set_squared_distances_to_intersecting_bodies( TypedArray<float> squared_distances_to_intersecting_bodies ) {
+    _has_sensor_value_changed = _has_sensor_value_changed || (_squared_distances_to_intersecting_bodies != squared_distances_to_intersecting_bodies);
+    _squared_distances_to_intersecting_bodies = squared_distances_to_intersecting_bodies;
+}
 
 TypedArray<float> UtilityAIArea3DVisibilitySensor::get_squared_distances_to_intersecting_areas() const {
     return _squared_distances_to_intersecting_areas;
+}
+
+TypedArray<float> UtilityAIArea3DVisibilitySensor::get_squared_distances_to_intersecting_bodies() const {
+    return _squared_distances_to_intersecting_bodies;
 }
 
 
@@ -500,8 +649,16 @@ void UtilityAIArea3DVisibilitySensor::set_squared_distances_to_unoccluded_areas(
     _squared_distances_to_unoccluded_areas = squared_distances_to_unoccluded_areas;
 }
 
+void UtilityAIArea3DVisibilitySensor::set_squared_distances_to_unoccluded_bodies( TypedArray<float> squared_distances_to_unoccluded_bodies ) {
+    _has_sensor_value_changed = _has_sensor_value_changed || (_squared_distances_to_unoccluded_bodies != squared_distances_to_unoccluded_bodies);
+    _squared_distances_to_unoccluded_bodies = squared_distances_to_unoccluded_bodies;
+}
+
 
 TypedArray<float> UtilityAIArea3DVisibilitySensor::get_squared_distances_to_unoccluded_areas() const {
     return _squared_distances_to_unoccluded_areas;
 }
 
+TypedArray<float> UtilityAIArea3DVisibilitySensor::get_squared_distances_to_unoccluded_bodies() const {
+    return _squared_distances_to_unoccluded_bodies;
+}

--- a/src/agent_behaviours/sensors/area3d_visibility.h
+++ b/src/agent_behaviours/sensors/area3d_visibility.h
@@ -1,8 +1,9 @@
 #ifndef UTILITYAIArea3DVisibilitySENSOR_H_INCLUDED
-#define UTILITYAIArea3DVisibilitySENSOR_H_INCLUDED 
+#define UTILITYAIArea3DVisibilitySENSOR_H_INCLUDED
 
 #include "../sensor.h"
 #include <godot_cpp/classes/area3d.hpp>
+#include <godot_cpp/classes/node3d.hpp>
 
 namespace godot {
 
@@ -19,12 +20,17 @@ private:
 
     TypedArray<RID>    _occlusion_test_exclusion_list;
     TypedArray<Area3D> _intersecting_areas;
+    TypedArray<Node3D> _intersecting_bodies;
     TypedArray<Area3D> _unoccluded_areas;
     TypedArray<Node3D> _unoccluded_bodies;
     TypedArray<float>  _squared_distances_to_intersecting_areas;
     TypedArray<float>  _squared_distances_to_unoccluded_areas;
+    TypedArray<float>  _squared_distances_to_intersecting_bodies;
+    TypedArray<float>  _squared_distances_to_unoccluded_bodies;
     int _closest_intersecting_area_index;
     int _closest_unoccluded_area_index;
+    int _closest_intersecting_body_index;
+    int _closest_unoccluded_body_index;
 
     int _expected_number_of_areas_to_track;
     int _expected_number_of_bodies_to_track;
@@ -46,9 +52,9 @@ public:
     // Godot virtuals.
     //void _ready();
     //void _notification( int p_what );
-   
-    
-    // Handling functions. 
+
+
+    // Handling functions.
     virtual void initialize_sensor() override;
     virtual void uninitialize_sensor() override;
 
@@ -56,10 +62,12 @@ public:
 
     void on_area_entered(Area3D* area );
     void on_area_exited(Area3D* area );
+    void on_body_entered(Node3D* body );
+    void on_body_exited(Node3D* body );
 
     // Getters and setters for attributes.
-    
-    // Configuration values. 
+
+    // Configuration values.
 
     void set_use_owner_global_position( bool use_owner_global_position );
     bool get_use_owner_global_position() const;
@@ -84,20 +92,27 @@ public:
 
     void set_occlusion_test_exclusion_list( TypedArray<RID> occlusion_test_exclusion_list );
     TypedArray<RID> get_occlusion_test_exclusion_list() const;
-    
+
     // Debugging / current values.
 
     void set_num_entities_found( int num_entities_found );
     int  get_num_entities_found() const;
-    
+
     void set_closest_intersecting_area_index( int closest_intersecting_area_index );
     int  get_closest_intersecting_area_index() const;
+    void set_closest_intersecting_body_index( int closest_intersecting_body_index );
+    int  get_closest_intersecting_body_index() const;
 
     void set_closest_unoccluded_area_index( int closest_unoccluded_area_index );
     int  get_closest_unoccluded_area_index() const;
+    void set_closest_unoccluded_body_index( int closest_unoccluded_body_index );
+    int  get_closest_unoccluded_body_index() const;
 
     void set_intersecting_areas( TypedArray<Area3D> intersecting_areas );
     TypedArray<Area3D> get_intersecting_areas() const;
+
+    void set_intersecting_bodies( TypedArray<Node3D> intersecting_bodies );
+    TypedArray<Node3D> get_intersecting_bodies() const;
 
     void set_unoccluded_areas( TypedArray<Area3D> unoccluded_areas );
     TypedArray<Area3D> get_unoccluded_areas() const;
@@ -108,13 +123,17 @@ public:
     void set_squared_distances_to_intersecting_areas( TypedArray<float> squared_distances_to_intersecting_areas );
     TypedArray<float> get_squared_distances_to_intersecting_areas() const;
 
+    void set_squared_distances_to_intersecting_bodies( TypedArray<float> squared_distances_to_intersecting_bodies );
+    TypedArray<float> get_squared_distances_to_intersecting_bodies() const;
+
     void set_squared_distances_to_unoccluded_areas( TypedArray<float> squared_distances_to_unoccluded_areas );
     TypedArray<float> get_squared_distances_to_unoccluded_areas() const;
 
-
+    void set_squared_distances_to_unoccluded_bodies( TypedArray<float> squared_distances_to_unoccluded_bodies );
+    TypedArray<float> get_squared_distances_to_unoccluded_bodies() const;
 };
 
 }
 
 
-#endif 
+#endif

--- a/src/node_query_system/search_criteria/custom.cpp
+++ b/src/node_query_system/search_criteria/custom.cpp
@@ -2,6 +2,9 @@
 
 using namespace godot;
 
+void UtilityAICustomSearchCriterion::_bind_methods() {
+
+}
 
 
 UtilityAICustomSearchCriterion::UtilityAICustomSearchCriterion() {

--- a/src/node_query_system/search_criteria/custom.h
+++ b/src/node_query_system/search_criteria/custom.h
@@ -1,5 +1,5 @@
 #ifndef UtilityAICustomSearchCriterion_H_INCLUDED
-#define UtilityAICustomSearchCriterion_H_INCLUDED 
+#define UtilityAICustomSearchCriterion_H_INCLUDED
 
 #include "nqs.h"
 
@@ -9,15 +9,15 @@ class UtilityAICustomSearchCriterion : public UtilityAINQSSearchCriteria {
     GDCLASS(UtilityAICustomSearchCriterion, UtilityAINQSSearchCriteria)
 
 private:
-    
+
 protected:
-    //static void _bind_methods();
+    static void _bind_methods();
 
 public:
     UtilityAICustomSearchCriterion();
     ~UtilityAICustomSearchCriterion();
-    
-    
+
+
     // Getters and setters for attributes.
 
 
@@ -30,4 +30,4 @@ public:
 }
 
 
-#endif 
+#endif

--- a/src/state_tree/node.cpp
+++ b/src/state_tree/node.cpp
@@ -21,15 +21,20 @@ using namespace godot;
     //ClassDB::bind_method(D_METHOD("tick", "user_data", "delta"), &UtilityAISTSelector::tick);
 //}
 
+void UtilityAISTNode::_bind_methods() {
+
+}
+
 
 // Constructor and destructor.
 
 UtilityAISTNode::UtilityAISTNode() {
-    
+
 }
 
 
 UtilityAISTNode::~UtilityAISTNode() {
+
 }
 
 
@@ -43,7 +48,7 @@ UtilityAISTNode::~UtilityAISTNode() {
 // Handling functions.
 
 /**
-UtilityAISTNodes* UtilityAISTSelector::_tick(Variant user_data, double delta) { 
+UtilityAISTNodes* UtilityAISTSelector::_tick(Variant user_data, double delta) {
 
     // The selector will only consider the state tree nodes.
     UtilityAISTNodes* result_state = nullptr;

--- a/src/state_tree/node.h
+++ b/src/state_tree/node.h
@@ -1,5 +1,5 @@
 #ifndef UtilityAISTSelector_H_INCLUDED
-#define UtilityAISTSelector_H_INCLUDED 
+#define UtilityAISTSelector_H_INCLUDED
 
 #include "nodes.h"
 //#include <godot_cpp/classes/node.hpp>
@@ -15,14 +15,15 @@ private:
 
 
 protected:
+    static void _bind_methods();
 
 public:
     UtilityAISTNode();
     ~UtilityAISTNode();
-    
+
 };
 
 }
 
 
-#endif 
+#endif


### PR DESCRIPTION
Requires https://github.com/JarkkoPar/Utility_AI/pull/9

This PR adds bodies support to the `UtilityAIArea3DVisibilitySensor` sensor. 

I also moved Area and Body fields into their respective subgroups to make things easier to see and work with:
![image](https://github.com/user-attachments/assets/1bde9f3b-8c82-49d8-95b4-47f562a82aa8)

MRP here [demo.zip](https://github.com/user-attachments/files/18573878/demo.zip)
Hit play, open remote tab and navigate to the `UtilityAIArea3DVisibilitySensor`. As the boxes enter the giant Area3D you'll see the area and body numbers go up, as they leave the numbers go down. Each box entering/exiting has both an area and body.