### PR TITLE
Fix body occlusion tests, stop areas/bodies occluding themselves

### DIFF
--- a/src/agent_behaviours/sensors/area2d_visibility.cpp
+++ b/src/agent_behaviours/sensors/area2d_visibility.cpp
@@ -300,7 +300,7 @@ float UtilityAIArea2DVisibilitySensor::evaluate_sensor_value() {
             params->set_collide_with_areas(true);
             //params->set_block_signals(true);
             Dictionary results = dss->intersect_ray( params );
-            if( results.is_empty() ) {
+            if( results.is_empty() || results.get("collider", nullptr) == _intersecting_areas[i] ) {
                 _unoccluded_areas.push_back(area);
                 _squared_distances_to_unoccluded_areas.push_back(distance_squared);
                 if( _closest_unoccluded_area_index == -1 ) {
@@ -350,7 +350,7 @@ float UtilityAIArea2DVisibilitySensor::evaluate_sensor_value() {
             // params->set_collide_with_areas(true);
             //params->set_block_signals(true);
             Dictionary results = dss->intersect_ray( params );
-            if( results.is_empty() ) {
+            if( results.is_empty() || results.get("collider", nullptr) == _intersecting_bodies[i] ) {
                 _unoccluded_areas.push_back(body);
                 _squared_distances_to_unoccluded_bodies.push_back(distance_squared);
                 if( _closest_unoccluded_body_index == -1 ) {

--- a/src/agent_behaviours/sensors/area3d_visibility.cpp
+++ b/src/agent_behaviours/sensors/area3d_visibility.cpp
@@ -288,7 +288,7 @@ float UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
             params->set_collide_with_areas(true);
             //params->set_block_signals(true);
             Dictionary results = dss->intersect_ray( params );
-            if( results.is_empty() ) {
+            if( results.is_empty() || results.get("collider", nullptr) == _intersecting_areas[i]  ) {
                 _unoccluded_areas.push_back(area);
                 _squared_distances_to_unoccluded_areas.push_back(distance_squared);
                 if( _closest_unoccluded_area_index == -1 ) {
@@ -313,7 +313,7 @@ float UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
         }
         Vector3 body_position = body->get_global_position();
 
-        // Calculate the distance to the area.
+        // Calculate the distance to the body.
         Vector3 from_to = body_position - offset_from_vector;
         float distance_squared = from_to.length_squared();
         _squared_distances_to_intersecting_bodies.push_back(distance_squared);
@@ -339,14 +339,14 @@ float UtilityAIArea3DVisibilitySensor::evaluate_sensor_value() {
             params->set_collide_with_areas(false);
             //params->set_block_signals(true);
             Dictionary results = dss->intersect_ray( params );
-            if( results.is_empty() ) {
+            if( results.is_empty() || results.get("collider", nullptr) == _intersecting_bodies[i] ) {
                 _unoccluded_bodies.push_back(body);
                 _squared_distances_to_unoccluded_bodies.push_back(distance_squared);
                 if( _closest_unoccluded_body_index == -1 ) {
-                    _closest_unoccluded_body_index = found_unoccluded_areas;
+                    _closest_unoccluded_body_index = found_unoccluded_bodies;
                     closest_unoccluded_body_distance = distance_squared;
                 } else if( closest_unoccluded_body_distance > distance_squared ) {
-                    _closest_unoccluded_body_index = found_unoccluded_areas;
+                    _closest_unoccluded_body_index = found_unoccluded_bodies;
                     closest_unoccluded_body_distance = distance_squared;
                 }
                 ++found_unoccluded_bodies;


### PR DESCRIPTION
This PR makes two changes:
1. Fixes a bug where the variable `found_unoccluded_areas` is being used mistakenly. It should be `found_unoccluded_bodies`
https://github.com/JarkkoPar/Utility_AI/blob/ab10e11f32e9bf4dd44c69616e1a13eb522a9c6c/src/agent_behaviours/sensors/area3d_visibility.cpp#L346-L349
2. During occlusion checks, stops areas/bodies from occluding themselves - Say you have an Area3D with collision layer/mask 1, a body inside the same, and an Area3DSensor with collision mask 1 - The sensor will detect the body inside but the raycast from the area to the body will hit the body and it'll occlude itself even with direct line of sight.

MRP with two test scenes:  [demo.zip](https://github.com/user-attachments/files/18639288/demo.zip)
