### PR TITLE
Add automated builds

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,0 +1,64 @@
+name: Build Android
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: double
+            arch: arm64
+            platform: android
+            target-type: template_debug
+          - precision: double
+            arch: x86_64
+            platform: android
+            target-type: template_debug
+          - precision: double
+            arch: arm64
+            platform: android
+            target-type: template_release
+          - precision: double
+            arch: x86_64
+            platform: android
+            target-type: template_release
+
+    # Taken mostly from https://github.com/godotengine/godot-cpp-template/blob/main/.github/workflows/builds.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      # Setup dependencies
+      - name: Setup godot-cpp
+        uses: ./godot-cpp/.github/actions/setup-godot-cpp
+        with:
+          platform: ${{ matrix.platform }}
+          em-version: 3.1.62
+
+      # Build GDExtension (with caches)
+      - name: Cache .scons_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.scons-cache/
+          key: ${{ matrix.platform }}_${{ matrix.arch }}_${{ matrix.precision }}_${{ matrix.target-type }}_cache
+
+      - name: Build GDExtension
+        shell: sh
+        env:
+          SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+        run: |
+          scons target=${{ matrix.target-type }} platform=${{ matrix.platform }} arch=${{ matrix.arch }} precision=${{ matrix.precision }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libutilityai-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.precision }}-${{ matrix.target-type }}
+          path: ${{ github.workspace }}/demo/addons/utility_ai/bin/*.so
+          if-no-files-found: error

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,56 @@
+name: Build Linux
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: double
+            arch: x86_64
+            platform: linux
+            target-type: template_debug
+          - precision: double
+            arch: x86_64
+            platform: linux
+            target-type: template_release
+
+    # Taken mostly from https://github.com/godotengine/godot-cpp-template/blob/main/.github/workflows/builds.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      # Setup dependencies
+      - name: Setup godot-cpp
+        uses: ./godot-cpp/.github/actions/setup-godot-cpp
+        with:
+          platform: ${{ matrix.platform }}
+          em-version: 3.1.62
+
+      # Build GDExtension (with caches)
+      - name: Cache .scons_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.scons-cache/
+          key: ${{ matrix.platform }}_${{ matrix.arch }}_${{ matrix.precision }}_${{ matrix.target-type }}_cache
+
+      - name: Build GDExtension
+        shell: sh
+        env:
+          SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+        run: |
+          scons target=${{ matrix.target-type }} platform=${{ matrix.platform }} arch=${{ matrix.arch }} precision=${{ matrix.precision }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libutilityai-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.precision }}-${{ matrix.target-type }}
+          path: ${{ github.workspace }}/demo/addons/utility_ai/bin/*.so
+          if-no-files-found: error

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -1,0 +1,56 @@
+name: Build Web
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: double
+            arch: wasm32
+            platform: web
+            target-type: template_debug
+          - precision: double
+            arch: wasm32
+            platform: web
+            target-type: template_release
+
+    # Taken mostly from https://github.com/godotengine/godot-cpp-template/blob/main/.github/workflows/builds.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      # Setup dependencies
+      - name: Setup godot-cpp
+        uses: ./godot-cpp/.github/actions/setup-godot-cpp
+        with:
+          platform: ${{ matrix.platform }}
+          em-version: 3.1.62
+
+      # Build GDExtension (with caches)
+      - name: Cache .scons_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.scons-cache/
+          key: ${{ matrix.platform }}_${{ matrix.arch }}_${{ matrix.precision }}_${{ matrix.target-type }}_cache
+
+      - name: Build GDExtension
+        shell: sh
+        env:
+          SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+        run: |
+          scons target=${{ matrix.target-type }} platform=${{ matrix.platform }} arch=${{ matrix.arch }} precision=${{ matrix.precision }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libutilityai-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.precision }}-${{ matrix.target-type }}
+          path: ${{ github.workspace }}/demo/addons/utility_ai/bin/*.wasm
+          if-no-files-found: error

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,65 @@
+name: Build Windows
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: double
+            arch: x86_64
+            opencl_arch: x64
+            target-type: template_debug
+            platform: windows
+          - precision: double
+            arch: x86_64
+            opencl_arch: x64
+            target-type: template_release
+            platform: windows
+
+    # Taken mostly from https://github.com/godotengine/godot-cpp-template/blob/main/.github/workflows/builds.yml
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      # Setup dependencies
+      - name: Setup godot-cpp
+        uses: ./godot-cpp/.github/actions/setup-godot-cpp
+        with:
+          platform: ${{ matrix.platform }}
+          em-version: 3.1.62
+
+      # Build GDExtension (with caches)
+      - name: Cache .scons_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.scons-cache/
+          key: ${{ matrix.platform }}_${{ matrix.arch }}_${{ matrix.precision }}_${{ matrix.target-type }}_cache
+
+      - name: Build GDExtension
+        shell: sh
+        env:
+          SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+        run: |
+          scons target=${{ matrix.target-type }} platform=${{ matrix.platform }} arch=${{ matrix.arch }} precision=${{ matrix.precision }}
+
+      # Clean up compilation files
+      - name: Delete compilation files
+        shell: pwsh
+        run: |
+          Remove-Item ${{ github.workspace }}/demo/addons/utility_ai/bin/* -Include *.exp,*.lib,*.pdb -Force
+
+      # Upload the build
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libutilityai-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.precision }}-${{ matrix.target-type }}
+          path: ${{ github.workspace }}/demo/addons/utility_ai/bin/*.dll
+          if-no-files-found: error

--- a/.github/workflows/group_builds.yml
+++ b/.github/workflows/group_builds.yml
@@ -1,0 +1,32 @@
+name: Build Linux
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Download Build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path:  ${{ github.workspace }}/demo/addons/utility_ai/bin/
+          merge-multiple: true
+
+      - name: Delete Build artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: libutilityai-*
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: utility_ai_demo_project
+          path: ${{ github.workspace }}/demo/
+          if-no-files-found: error

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,0 +1,21 @@
+name: Builds
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+    build_android:
+        uses: ./.github/workflows/build_android.yml
+    # build_ios:
+    #     uses: ./.github/workflows/build_ios.yml
+    build_linux:
+        uses: ./.github/workflows/build_linux.yml
+    build_windows:
+        uses: ./.github/workflows/build_windows.yml
+    build_web:
+        uses: ./.github/workflows/build_web.yml
+    group_builds:
+        needs: [build_android, build_linux, build_windows, build_web]
+        uses: ./.github/workflows/group_builds.yml

--- a/demo/addons/utility_ai/bin/libutilityai.gdextension
+++ b/demo/addons/utility_ai/bin/libutilityai.gdextension
@@ -5,10 +5,16 @@ compatibility_minimum = 4.1
 
 [libraries]
 
-windows.debug.x86_64 = "res://addons/utility_ai/bin/libutilityai.windows.template_debug.x86_64.dll"
-windows.release.x86_64 = "res://addons/utility_ai/bin/libutilityai.windows.template_release.x86_64.dll"
-linux.debug.x86_64 = "res://addons/utility_ai/bin/libutilityai.linux.template_debug.x86_64.so"
-linux.release.x86_64 = "res://addons/utility_ai/bin/libutilityai.linux.template_release.x86_64.so"
+android.debug.x86_64 = "res://addons/utility_ai/bin/libutilityai.android.template_debug.double.x86_64.so"
+android.release.x86_64 = "res://addons/utility_ai/bin/libutilityai.android.template_release.double.x86_64.so"
+android.debug.arm64 = "res://addons/utility_ai/bin/libutilityai.android.template_debug.double.arm64.so"
+android.release.arm64 = "res://addons/utility_ai/bin/libutilityai.android.template_release.double.arm64.so"
+windows.debug.x86_64 = "res://addons/utility_ai/bin/libutilityai.windows.template_debug.double.x86_64.dll"
+windows.release.x86_64 = "res://addons/utility_ai/bin/libutilityai.windows.template_release.double.x86_64.dll"
+linux.debug.x86_64 = "res://addons/utility_ai/bin/libutilityai.linux.template_debug.double.x86_64.so"
+linux.release.x86_64 = "res://addons/utility_ai/bin/libutilityai.linux.template_release.double.x86_64.so"
+web.debug.wasm32 = "res://addons/utility_ai/bin/libutilityai.web.template_debug.double.wasm32.so"
+web.release.wasm32 = "res://addons/utility_ai/bin/libutilityai.web.template_release.double.wasm32.so"
 
 [icons]
 UtilityAI = "res://addons/utility_ai/icons/UtilityAIDefault.svg"


### PR DESCRIPTION
This PR adds automated builds on `push` and `pull_request`. It creates an downloadable artifact containing the demo project compiled for windows, linux, android and web.

This is what the workflow looks like:
![image](https://github.com/user-attachments/assets/3669434c-f037-489c-969f-c042cf9e5f97)


The downloaded zip file contains all the compiled extension files in the one example project:
![image](https://github.com/user-attachments/assets/ee415e02-929d-4976-9c7a-965755b34b88)

If you merge both this and my lint workflow PR (https://github.com/JarkkoPar/Utility_AI/pull/19) I suggest updating *.github/workflows/runner.yml* to the following:

```yaml
name: Builds

on:
    workflow_dispatch:
    pull_request:
    push:

jobs:
    lint:
        uses: ./.github/workflows/lint.yml
    build_android:
        needs: [lint]
        uses: ./.github/workflows/build_android.yml
    build_linux:
        needs: [lint]
        uses: ./.github/workflows/build_linux.yml
    build_windows:
        needs: [lint]
        uses: ./.github/workflows/build_windows.yml
    build_web:
        needs: [lint]
        uses: ./.github/workflows/build_web.yml
    group_builds:
        needs: [build_android, build_linux, build_windows, build_web]
        uses: ./.github/workflows/group_builds.yml
```

Note: My screenshots show the download as being called `example_project` but I've since renamed it to `demo_project` to match the folder name you've got in this repo.