### PR TITLE
Make UtilityAIConsideration 'eval()' method work.

### DIFF
--- a/src/agent_behaviours/consideration.cpp
+++ b/src/agent_behaviours/consideration.cpp
@@ -34,7 +34,7 @@ UtilityAIConsideration::UtilityAIConsideration() {
     _input_sensor = nullptr;
     _has_custom_evaluation_method = false;
     _has_activation_input_changed = true;
-    
+
 }
 
 
@@ -78,7 +78,7 @@ float UtilityAIConsideration::get_activation_input_value() const {
 void UtilityAIConsideration::_notification(int p_what) {
 	switch (p_what) {
         case NOTIFICATION_ENTER_TREE: {
-            // Entered the tree. 
+            // Entered the tree.
         } break;
 		case NOTIFICATION_EXIT_TREE: {
 			//_clear_monitoring();
@@ -89,7 +89,7 @@ void UtilityAIConsideration::_notification(int p_what) {
 
 // Handling methods.
 
-float UtilityAIConsideration::evaluate() { 
+float UtilityAIConsideration::evaluate() {
     #ifdef DEBUG_ENABLED
     _last_evaluated_timestamp = godot::Time::get_singleton()->get_ticks_usec();
     #endif
@@ -134,10 +134,18 @@ void UtilityAIConsideration::_evaluate_consideration() {
         call("eval");
         return;
     }
-    
+
     if(_activation_curve.is_valid()) {
 		_score = _activation_curve->sample( _activation_input_value );
 	} else {
         _score = _activation_input_value;
     }
+}
+
+void UtilityAIConsideration::_notification(int p_what) {
+    if( p_what != NOTIFICATION_POST_ENTER_TREE ) {
+        return;
+    }
+
+    _has_custom_evaluation_method = has_method("eval");
 }

--- a/src/agent_behaviours/consideration.h
+++ b/src/agent_behaviours/consideration.h
@@ -1,5 +1,5 @@
 #ifndef UtilityAIConsideration_H_INCLUDED
-#define UtilityAIConsideration_H_INCLUDED 
+#define UtilityAIConsideration_H_INCLUDED
 
 #include "considerations.h"
 #include "sensors.h"
@@ -13,7 +13,7 @@ class UtilityAIConsideration : public UtilityAIConsiderations {
     GDCLASS(UtilityAIConsideration, UtilityAIConsiderations )
 
 private:
-    
+
 protected:
     static void _bind_methods();
 
@@ -27,8 +27,8 @@ protected:
 public:
     UtilityAIConsideration();
     ~UtilityAIConsideration();
-    
-    
+
+
     // Getters and setters for attributes.
 
     void set_input_sensor( UtilityAISensors* input_sensor );
@@ -40,12 +40,12 @@ public:
     void set_activation_input_value( float activation_input_value );
     float get_activation_input_value() const;
 
-            
+
     // Godot virtuals.
-    //void _notification( int p_what );
-   
+    virtual void _notification( int p_what );
+
     // Handling functions.
-    
+
     virtual float evaluate() override;
     virtual float sample_activation_curve( float input_value ) const;
 };
@@ -53,4 +53,4 @@ public:
 }
 
 
-#endif 
+#endif


### PR DESCRIPTION
Makes the UtilityAIConsideration `eval()` method work. Docs [here](https://github.com/JarkkoPar/Utility_AI_GDExtension/blob/main/documentation/Nodes_latest.md#utilityaiconsideration-and-utilityaiconsiderationgroup).

Fixes https://github.com/JarkkoPar/Utility_AI_GDExtension/issues/20

MRP: [demo.zip](https://github.com/user-attachments/files/18728615/demo.zip)
Run the game. The logo will only rotate when on the right side of the screen because of the following consideration eval method:

```gdscript
func eval() -> void:
	var val: int = 1 if activation_input_value < 0.5 else 0

	score = sample_activation_curve(val)
```

Interestingly I found you can't call print() from the `eval()` method. Not sure what that's about. Someone smarter than me should know.